### PR TITLE
-cp instead of -jar for java command

### DIFF
--- a/src/main/java/org/dipert/abcl/plugin/AbstractABCLMojo.java
+++ b/src/main/java/org/dipert/abcl/plugin/AbstractABCLMojo.java
@@ -108,12 +108,12 @@ public abstract class AbstractABCLMojo extends AbstractMojo {
     }
 
 
-    private String getPath(File[] sourceDirectory) {
+    protected String getPath(File[] sourceDirectory) {
         String cp = "";
         for (File directory : sourceDirectory) {
-            cp = cp + directory.toURI() + " ";
+            cp = cp + directory.getPath() + File.pathSeparator;
         }
-        return cp;
+        return cp.substring(0, cp.length() - 1);
     }
 
     protected String manifestClasspath(final File[] sourceDirectory, final File outputDirectory, final List<String> compileClasspathElements) {

--- a/src/main/java/org/dipert/abcl/plugin/REPLMojo.java
+++ b/src/main/java/org/dipert/abcl/plugin/REPLMojo.java
@@ -23,16 +23,23 @@ public class REPLMojo extends AbstractABCLMojo {
 
     File[] sourceDirectory = getSourceDirectories(SourceDirectory.TEST, SourceDirectory.COMPILE);
     List<String> compileClasspathElements = getRunWithClasspathElements();
-    String classpath = manifestClasspath(sourceDirectory, outputDirectory, compileClasspathElements);
+    String cp = getPath(sourceDirectory);
+    cp = cp + File.pathSeparator + outputDirectory.getPath() + File.pathSeparator;
+    for (Object classpathElement : compileClasspathElements) {
+      cp = cp + File.pathSeparator + classpathElement;
+    }
+    cp = cp.replaceAll("\\s", "\\ ");
+
     final String javaExecutable = getJavaExecutable();
 
     getLog().debug("Java executable used:  " + javaExecutable);
-    getLog().debug("ABCL manifest classpath: " + classpath);
+    getLog().debug("ABCL classpath: " + cp);
 
     CommandLine cl = new CommandLine(javaExecutable);
-    cl.addArgument("-jar");
-    File jar = createJar(classpath, mainClass);
-    cl.addArgument(jar.getAbsolutePath(), false);
+
+    cl.addArgument("-cp");
+    cl.addArgument(cp, false);
+    cl.addArgument(mainClass);
 
     getLog().debug("Command line: " + cl.toString());
 


### PR DESCRIPTION
clojure-maven-plugin, on which this plugin is based, builds a .jar and
populates the classpath attribute of its manifest with all the classpath
elements. This is done to avoid a "command string too long" error on
Windows, but is incompatible with the way (require :abcl-contrib) works.
A change to ABCL's mechanism for finding .asd is the underlying fix.